### PR TITLE
Remove redundant _paginator from docs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ class CustomPaginator < JSONAPI::Paginator
   end
 ```
 
-And then it can be either set at the resource class level (e.g. UserResource.paginator :custom_paginator) or via config initializer:
+And then it can be either set at the resource class level (e.g. UserResource.paginator :custom) or via config initializer:
 
 ```ruby
 # config/initializers/jsonapi_resources.rb
 JSONAPI.configure do |config|
-  config.default_paginator = :custom_paginator
+  config.default_paginator = :custom
 end
 ```
 


### PR DESCRIPTION
There is no need to add _paginator in pagination config- paginator_klass do this already:

def paginator_klass
  "#{JSONAPI.configuration.default_paginator}_paginator".classify.constantize
end